### PR TITLE
remove AllowForHeavyElements env var (removed in G4 10.6.x?)

### DIFF
--- a/Dockerfile.G4-11-0
+++ b/Dockerfile.G4-11-0
@@ -116,8 +116,7 @@ ENV PATH="/opt/geant4/bin:$PATH" \
     G4RADIOACTIVEDATA="/opt/geant4/share/Geant4-${GEANT4_VERSION}/data/RadioactiveDecay5.6" \
     G4REALSURFACEDATA="/opt/geant4/share/Geant4-${GEANT4_VERSION}/data/RealSurface2.2" \
     G4SAIDXSDATA="/opt/geant4/share/Geant4-${GEANT4_VERSION}/data/G4SAIDDATA2.0" \
-    G4TENDLDATA="/opt/geant4/share/Geant4-${GEANT4_VERSION}/data/G4TENDL1.4" \
-    AllowForHeavyElements=1
+    G4TENDLDATA="/opt/geant4/share/Geant4-${GEANT4_VERSION}/data/G4TENDL1.4"
 
 RUN mkdir -p src build /opt/bxdecay0 && \
     git lfs install && \

--- a/Dockerfile.G4-11-0.vtk
+++ b/Dockerfile.G4-11-0.vtk
@@ -138,8 +138,7 @@ ENV PATH="/opt/geant4/bin:$PATH" \
     G4RADIOACTIVEDATA="/opt/geant4/share/Geant4-11.0.0/data/RadioactiveDecay5.6" \
     G4REALSURFACEDATA="/opt/geant4/share/Geant4-11.0.0/data/RealSurface2.2" \
     G4SAIDXSDATA="/opt/geant4/share/Geant4-11.0.0/data/G4SAIDDATA2.0" \
-    G4TENDLDATA="/opt/geant4/share/Geant4-11.0.0/data/G4TENDL1.4" \
-    AllowForHeavyElements=1
+    G4TENDLDATA="/opt/geant4/share/Geant4-11.0.0/data/G4TENDL1.4"
 
 ARG BXDECAY0_VERSION="git"
 

--- a/Dockerfile.G4-11-1
+++ b/Dockerfile.G4-11-1
@@ -102,10 +102,8 @@ RUN mkdir -p src build /opt/geant4 && \
     make -j"$(nproc)" install && \
     cd .. && rm -rf src build
 
-# there's no alternative to setting env vars explicitly
 ENV PATH="/opt/geant4/bin:$PATH" \
-    LD_LIBRARY_PATH="/opt/geant4/lib:$LD_LIBRARY_PATH" \
-    AllowForHeavyElements=1
+    LD_LIBRARY_PATH="/opt/geant4/lib:$LD_LIBRARY_PATH"
 
 RUN mkdir -p src build /opt/bxdecay0 && \
     git lfs install && \

--- a/Dockerfile.G4-11-2
+++ b/Dockerfile.G4-11-2
@@ -102,10 +102,8 @@ RUN mkdir -p src build /opt/geant4 && \
     make -j"$(nproc)" install && \
     cd .. && rm -rf src build
 
-# there's no alternative to setting env vars explicitly
 ENV PATH="/opt/geant4/bin:$PATH" \
-    LD_LIBRARY_PATH="/opt/geant4/lib:$LD_LIBRARY_PATH" \
-    AllowForHeavyElements=1
+    LD_LIBRARY_PATH="/opt/geant4/lib:$LD_LIBRARY_PATH"
 
 RUN mkdir -p src build /opt/bxdecay0 && \
     git lfs install && \


### PR DESCRIPTION
from the `particle_hp` changelog. This change was apparently merged in 4.10.6:

```
24 October 2019   (hadr-hpp-V10-05-08)
---------------------------------------------------
-  G4ParticleHPNames : remove restriction of using isotopes with Z > 92
   (threfore removing the environmental variable AllowForHeavyElements).
```