### PR TITLE
Add args to switch to latest vecgeom code

### DIFF
--- a/Dockerfile.G4-11-2
+++ b/Dockerfile.G4-11-2
@@ -4,10 +4,13 @@ LABEL maintainer.name="Luigi Pertoldi"
 LABEL maintainer.email="gipert@pm.me"
 
 ARG ROOT_VERSION="6.28.04"
-ARG VECGEOM_VERSION="1.2.6"
+ARG VECGEOM_VERSION="v1.2.6"
 ARG GEANT4_VERSION="11.2.2"
 ARG BXDECAY0_VERSION="1.1.2"
 ARG CMAKE_BUILD_TYPE="Release"
+
+# experimental feature in Geant4, enable at your own risk
+ARG GEANT4_USE_USOLIDS="OFF"
 
 USER root
 WORKDIR /root
@@ -28,7 +31,7 @@ ENV LC_ALL="en_US.utf8" \
 
 # build and install VecGeom
 RUN mkdir -p src build /opt/vecgeom && \
-    wget -q -O- "https://gitlab.cern.ch/VecGeom/VecGeom/-/archive/v${VECGEOM_VERSION}/VecGeom-v${VECGEOM_VERSION}.tar.gz" \
+    wget -q -O- "https://gitlab.cern.ch/VecGeom/VecGeom/-/archive/${VECGEOM_VERSION}/VecGeom-${VECGEOM_VERSION}.tar.gz" \
         | tar --strip-components 1 -C src --strip=1 -x -z && \
     cd build && \
     cmake \
@@ -93,7 +96,7 @@ RUN mkdir -p src build /opt/geant4 && \
         -DGEANT4_BUILD_MULTITHREADED=ON \
 # libhdf5must be compiled in thread-safe mode, if GEANT4 multithreading is enabled
         -DGEANT4_USE_HDF5=ON \
-        # -DGEANT4_USE_USOLIDS=ON \
+        -DGEANT4_USE_USOLIDS=${GEANT4_USE_USOLIDS} \
         -DGEANT4_USE_QT=ON \
         -DGEANT4_USE_INVENTOR_QT=ON \
         -DGEANT4_USE_OPENGL_X11=ON \

--- a/Dockerfile.G4-11-3
+++ b/Dockerfile.G4-11-3
@@ -4,10 +4,13 @@ LABEL maintainer.name="Luigi Pertoldi"
 LABEL maintainer.email="gipert@pm.me"
 
 ARG ROOT_VERSION="6.28.04"
-ARG VECGEOM_VERSION="1.2.10"
+ARG VECGEOM_VERSION="v1.2.10"
 ARG GEANT4_VERSION="11.3.0"
 ARG BXDECAY0_VERSION="1.1.2"
 ARG CMAKE_BUILD_TYPE="Release"
+
+# experimental feature in Geant4, enable at your own risk
+ARG GEANT4_USE_USOLIDS="OFF"
 
 USER root
 WORKDIR /root
@@ -28,7 +31,7 @@ ENV LC_ALL="en_US.utf8" \
 
 # build and install VecGeom
 RUN mkdir -p src build /opt/vecgeom && \
-    wget -q -O- "https://gitlab.cern.ch/VecGeom/VecGeom/-/archive/v${VECGEOM_VERSION}/VecGeom-v${VECGEOM_VERSION}.tar.gz" \
+    wget -q -O- "https://gitlab.cern.ch/VecGeom/VecGeom/-/archive/${VECGEOM_VERSION}/VecGeom-${VECGEOM_VERSION}.tar.gz" \
         | tar --strip-components 1 -C src --strip=1 -x -z && \
     cd build && \
     cmake \
@@ -93,7 +96,7 @@ RUN mkdir -p src build /opt/geant4 && \
         -DGEANT4_BUILD_MULTITHREADED=ON \
 # libhdf5must be compiled in thread-safe mode, if GEANT4 multithreading is enabled
         -DGEANT4_USE_HDF5=ON \
-        # -DGEANT4_USE_USOLIDS=ON \
+        -DGEANT4_USE_USOLIDS=${GEANT4_USE_USOLIDS} \
         -DGEANT4_USE_QT=ON \
         -DGEANT4_USE_INVENTOR_QT=ON \
         -DGEANT4_USE_OPENGL_X11=ON \

--- a/build.sh
+++ b/build.sh
@@ -8,3 +8,7 @@ done
 
 docker build --pull --rm --build-arg CMAKE_BUILD_TYPE="RelWithDebInfo" \
              -t gipert/remage-base:G4.11.3-debuginfo -f Dockerfile.G4-11-3 .
+
+docker build --pull --rm --build-arg VECGEOM_VERSION="master" \
+             --build-arg GEANT4_USE_USOLIDS="ON" \
+             -t gipert/remage-base:G4.11.3-vecgeom-experimental -f Dockerfile.G4-11-3 .


### PR DESCRIPTION
building with `GEANT4_USE_USOLIDS="ON"` and `VECGEOM_VERSION="master"` should give us geant4 with the current VecGeom master branch

it would be nice to also have a "special" build of geant4 11.3 with this enabled somewhere (i.e. _not_ in the G4-11-3 tag). 11.3 had been tested with VecGeom 2.0.0-rc3, and master is only 6 commits ahead, so it should hopefully still compile fine